### PR TITLE
Sprockets 4 Support

### DIFF
--- a/lib/web_components_rails/haml_template.rb
+++ b/lib/web_components_rails/haml_template.rb
@@ -1,8 +1,0 @@
-require 'haml'
-
-class WebComponentsRails::HamlTemplate < Tilt::HamlTemplate
-  def prepare
-    @options = @options.merge(format: :html5)
-    super
-  end
-end

--- a/lib/web_components_rails/railtie.rb
+++ b/lib/web_components_rails/railtie.rb
@@ -21,7 +21,6 @@ class WebComponentsRails::Railtie < Rails::Railtie
       env.register_mime_type 'text/html', extensions: ['.html', '.haml']
       env.register_preprocessor 'text/html', Sprockets::DirectiveProcessor
       env.register_preprocessor 'text/html', WebComponentsRails::HTMLImportProcessor
-      env.register_engine '.haml', WebComponentsRails::HamlTemplate
       env.register_bundle_processor 'text/html', ::Sprockets::Bundle
     end
   end

--- a/lib/web_components_rails/version.rb
+++ b/lib/web_components_rails/version.rb
@@ -1,3 +1,3 @@
 module WebComponentsRails
-  VERSION = '1.2.2'
+  VERSION = '2.0.0'
 end

--- a/web_components_rails.gemspec
+++ b/web_components_rails.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogumbo', '>= 1.4.5'
   spec.add_dependency 'rails', '>= 4.0.0'
   spec.add_dependency 'sprockets-rails', '>= 2.0.0'
-  spec.add_dependency 'haml'
 
   spec.add_development_dependency 'rspec', '>= 3.0', '< 4.0'
 end


### PR DESCRIPTION
Adds support for sprockets 4, and silences all the warnings about `register_engine` being deprecated. Not sure anyone is using HAML to write web components, so this should be fine as a major version change.