### PR TITLE
Fixes issues with Nokogiri dropping values for boolean attributes

### DIFF
--- a/lib/web_components_rails/html_import_processor.rb
+++ b/lib/web_components_rails/html_import_processor.rb
@@ -6,7 +6,50 @@ require 'securerandom'
 #   https://github.com/rails/sprockets/blob/3.x/lib/sprockets/directive_processor.rb
 class WebComponentsRails::HTMLImportProcessor
 
-  VERSION = '9'
+  VERSION = '10'
+  URI_ATTRIBUTES = %w(
+    action
+    cite
+    data
+    formaction
+    href
+    itemid
+    manifest
+    ping
+    poster
+    src
+  ).freeze
+  BOOLEAN_ATTRIBUTES = %w(
+    allowfullscreen
+    allowpaymentrequest
+    allowusermedia
+    async
+    autofocus
+    autoplay
+    checked
+    controls
+    default
+    defer
+    disabled
+    formnovalidate
+    hidden
+    ismap
+    itemscope
+    loop
+    multiple
+    muted
+    nomodule
+    novalidate
+    open
+    playsinline
+    readonly
+    required
+    reversed
+    selected
+  ).freeze
+  XML_SAVE_OPTIONS = {
+    save_with: ::Nokogiri::XML::Node::SaveOptions::DEFAULT_XML | ::Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS
+  }
 
   def self.instance
     @instance ||= new
@@ -24,22 +67,22 @@ class WebComponentsRails::HTMLImportProcessor
     # Nokogiri/Nokogumbo are hard-coded to URI-escape certain attributes (src, href, action, and a[name]),
     # so we have to put in placeholders, and fix the values in the HTML string output afterwards
     # This doesn't work so well with framework-specific syntax (eg. <foo src="{{bar}}">)
-    placeholder_mapping = {}
-    %w(src href action).each do |name|
-      doc.css("[#{name}]").each do |node|
-        # The placeholders are just random strings
-        placeholder = SecureRandom.hex(40)
-        attr = node.attributes[name]
-        placeholder_mapping[placeholder] = attr.value
-        attr.value = placeholder
-      end
-    end
-    new_html = doc.to_html
-    placeholder_mapping.each do |placeholder, value|
-      new_html.sub!(placeholder, value)
+    doc_html = doc.to_html(encoding: 'UTF-8')
+
+    uri_regex = '(' + URI_ATTRIBUTES.join('|') + ')'
+    square_brackets_regex = Regexp.new("#{uri_regex}=\"%5B%5B(.+?)%5D%5D\"", 'i')
+    curly_braces_regex = Regexp.new("#{uri_regex}=\"%7B%7B(.+?)%7D%7D\"", 'i')
+
+    selectors = (URI_ATTRIBUTES + BOOLEAN_ATTRIBUTES).map { |attribute| "*[#{attribute}]"}
+    doc.css(selectors.join(',')).each do |node|
+      pattern = node.to_html
+      replacement = node.to_xml(XML_SAVE_OPTIONS)
+      replacement.gsub!(square_brackets_regex, '\1="[[\2]]"')
+      replacement.gsub!(curly_braces_regex, '\1="{{\2}}"')
+      doc_html.gsub!(pattern, replacement)
     end
 
-    new_html
+    doc_html
   end
 
 

--- a/lib/web_components_rails/version.rb
+++ b/lib/web_components_rails/version.rb
@@ -1,3 +1,3 @@
 module WebComponentsRails
-  VERSION = '2.1.3'
+  VERSION = '2.2.0'
 end

--- a/lib/web_components_rails/version.rb
+++ b/lib/web_components_rails/version.rb
@@ -1,3 +1,3 @@
 module WebComponentsRails
-  VERSION = '2.1.2'
+  VERSION = '2.1.3'
 end

--- a/spec/fixtures/complex1.html
+++ b/spec/fixtures/complex1.html
@@ -1,0 +1,2 @@
+<a href="{{url}}">Click</a>
+<select name="text"><option value="value1" selected="[[selected]]">Value 1</option></select>

--- a/spec/fixtures/complex2.html
+++ b/spec/fixtures/complex2.html
@@ -1,0 +1,1 @@
+<paper-checkbox checked$="[[checked]]">Check Me</paper-checkbox>

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -45,9 +45,14 @@ describe 'Integration with Rails' do
   it 'can process complex HTML assets' do
     compile_asset('complex1')
     expect(File.read(output_path)).to eq(
-      '<a href="{{url}}">Click</a>' + "\n" +
-      '<select name="text"><option value="value1" selected="[[selected]]">Value 1</option></select>' + "\n"
+      %{<a href="{{url}}">Click</a>\n} +
+      %{<select name="text"><option value="value1" selected="[[selected]]">Value 1</option></select>\n}
     )
+  end
+
+  it 'handles $= boolean attributes' do
+    compile_asset('complex2')
+    expect(File.read(output_path)).to eq(%{<paper-checkbox checked$="[[checked]]">Check Me</paper-checkbox>\n})
   end
 
   context 'given HTML with imports' do
@@ -60,14 +65,14 @@ describe 'Integration with Rails' do
     it 'concatenates the files in dependency order' do
       compile_asset('bundle')
       expect(File.read(output_path).gsub(/\n{2,}/, "\n")).to \
-        eq("<p>Component 1</p>\n<p>Component 3</p>\n<p>Component 2</p>\n")
+        eq(%{<p>Component 1</p>\n<p>Component 3</p>\n<p>Component 2</p>\n})
     end
 
     context 'with multiple scripts' do
       it 'keeps the scripts as-is' do
         compile_asset('bundle_js')
         expect(File.read(output_path).gsub(/\n{2,}/, "\n")).to \
-          eq("<component>\n<script>\nvar x = 1;\n</script>\n</component>\n<script>\nvar y = 2;\n</script>\n")
+          eq(%{<component>\n<script>\nvar x = 1;\n</script>\n</component>\n<script>\nvar y = 2;\n</script>\n})
       end
 
       context 'with WebComponentsRails.optimize_scripts = true' do
@@ -81,7 +86,7 @@ describe 'Integration with Rails' do
         it 'bundles, minifies, and inlines the scripts' do
           compile_asset('bundle_js')
           expect(File.read(output_path).gsub(/\n{2,}/, "\n")).to \
-            eq("<component>\n</component>\n<script src=\"data:text/javascript;base64,dmFyIHg9MSx5PTI7\"></script>")
+            eq(%{<component>\n</component>\n<script src=\"data:text/javascript;base64,dmFyIHg9MSx5PTI7\"></script>})
         end
       end
     end
@@ -101,11 +106,11 @@ describe 'Integration with Rails' do
 
     it 'inlines the JavaScript where the script tag was' do
       expect(File.read(output_path)).to eq(
-        "<p>Component 1</p>\n\n" +
-        "<script original-src=\"test.js\">\n" +
-        "#{original_js}\n" +
-        "</script>\n" +
-        "<div>My Component</div>\n"
+        %{<p>Component 1</p>\n\n} +
+        %{<script original-src=\"test.js\">\n} +
+        %{#{original_js}\n} +
+        %{</script>\n} +
+        %{<div>My Component</div>\n}
       )
     end
 
@@ -137,11 +142,11 @@ describe 'Integration with Rails' do
 
     it 'inlines the CSS where the link tag was' do
       expect(File.read(output_path)).to eq(
-        "<dom-module id=\"my-component\">\n" +
-        "    <template>\n" +
-        "        <style original-href=\"test.css\">\n#{original_css}\n</style>\n" +
-        "    </template>\n" +
-        "</dom-module>\n"
+        %{<dom-module id=\"my-component\">\n} +
+        %{    <template>\n} +
+        %{        <style original-href=\"test.css\">\n#{original_css}\n</style>\n} +
+        %{    </template>\n} +
+        %{</dom-module>\n}
       )
     end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -42,6 +42,14 @@ describe 'Integration with Rails' do
     expect(File.read(output_path)).to eq("<p>Component 1</p>\n")
   end
 
+  it 'can process complex HTML assets' do
+    compile_asset('complex1')
+    expect(File.read(output_path)).to eq(
+      "<a href=\"{{url}}\">Click</a>\n" +
+      "<select name=\"text\"><option value=\"value1\" selected=\"[[selected]]\">Value 1</option></select>\n"
+    )
+  end
+
   context 'given HTML with imports' do
     # Dependencies look like:
     #   bundle -> [simple1, simple2]

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -45,8 +45,8 @@ describe 'Integration with Rails' do
   it 'can process complex HTML assets' do
     compile_asset('complex1')
     expect(File.read(output_path)).to eq(
-      "<a href=\"{{url}}\">Click</a>\n" +
-      "<select name=\"text\"><option value=\"value1\" selected=\"[[selected]]\">Value 1</option></select>\n"
+      '<a href="{{url}}">Click</a>' + "\n" +
+      '<select name="text"><option value="value1" selected="[[selected]]">Value 1</option></select>' + "\n"
     )
   end
 


### PR DESCRIPTION
Currently `to_html` outputs valid HTML, meaning that values for these attributes that are bound using Polymer are dropped (e.g. `disabled="[[disabled]]"` is output as `disabled`). This also affects components added to our project via Bower such as `iron-list` and probably others.

The previous placeholder approach doesn't work for boolean attributes since Nokogiri simply drops the attribute values and the placeholder map then fails to find the key to replace the original value back into the attribute.